### PR TITLE
[Fix] Fix errors about `in` operator.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag =
 var toStr = Object.prototype.toString;
 
 var isStandardArguments = function isArguments(value) {
-	if (hasToStringTag && value && Symbol.toStringTag in value) {
+	if (hasToStringTag && value && typeof value === 'object' && Symbol.toStringTag in value) {
 		return false;
 	}
 	return toStr.call(value) === '[object Arguments]';

--- a/test.js
+++ b/test.js
@@ -7,7 +7,8 @@ var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag =
 test('primitives', function (t) {
 	t.notOk(isArguments([]), 'array is not arguments');
 	t.notOk(isArguments({}), 'object is not arguments');
-	t.notOk(isArguments(''), 'string is not arguments');
+	t.notOk(isArguments(''), 'empty string is not arguments');
+	t.notOk(isArguments('foo'), 'string is not arguments');
 	t.notOk(isArguments({ length: 2 }), 'naive array-like is not arguments');
 	t.end();
 });


### PR DESCRIPTION
I'm using 'to-file-path' package, which depends on this package. But cannot work after your package upgrade to '1.0.3'.

Error stack:

```
TypeError: Cannot use 'in' operator to search for 'Symbol(Symbol.toStringTag)' in 127.0.0.1
    at Function.isArguments (.../node_modules/is-arguments/index.js:7:52)
    at toFilePath (.../node_modules/to-file-path/index.js:37:36)
    at tofp (.../src/common/lib/ip_filter.js:70:35)
    at ipFilter (.../src/common/lib/ip_filter.js:63:29)
    at .../src/server/middlewares/ip_filter.js:65:22
    at .../node_modules/koa-mount/index.js:58:11
```

And this pull request just add check of `object` type before using `in` operator.

> The in operator can only be used to check if a property is in an object. You can't search in strings, or in numbers, or other primitive types.
> -- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/in_operator_no_object#What_went_wrong